### PR TITLE
feat: add auto-enablement for GitHub Pages Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,8 @@ jobs:
       - run: poetry install --with docs
       - run: poetry run mkdocs build --site-dir site
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site


### PR DESCRIPTION
- Add enablement: true to actions/configure-pages@v5
- This auto-creates/flips the Pages site to Actions backend if needed
- Resolves 'Get Pages site failed' 404 errors
- No manual repo settings changes required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site publishing configuration to explicitly enable Pages during deployments, improving reliability and consistency of releases.
  * Ensures the website remains enabled across environments and reduces the risk of accidental disablement during automated publishing.
  * No direct user-facing changes; this strengthens our deployment pipeline for smoother, more predictable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->